### PR TITLE
Fix socket communications using strings and config parsing

### DIFF
--- a/trollcast/client.py
+++ b/trollcast/client.py
@@ -77,7 +77,7 @@ class Subscriber(object):
             subscriber.setsockopt_string(SUBSCRIBE, "pytroll")
             subscriber.connect(addr)
             self.subscribers.append(subscriber)
-            self._poller.register(subscriber)
+            self._poller.register(subscriber, POLLIN)
         self._lock = Lock()
         self._loop = True
 
@@ -92,9 +92,12 @@ class Subscriber(object):
     def reset(self, addr):
         with self._lock:
             idx = self._addresses.index(addr)
-            self._poller.unregister(self.subscribers[idx])
-            self.subscribers[idx].setsockopt(LINGER, 0)
-            self.subscribers[idx].close()
+            try:
+                self._poller.unregister(self.subscribers[idx])
+                self.subscribers[idx].setsockopt(LINGER, 0)
+                self.subscribers[idx].close()
+            except KeyError:
+                pass
             self.subscribers[idx] = get_context().socket(SUB)
             self.subscribers[idx].setsockopt_string(SUBSCRIBE, "pytroll")
             self.subscribers[idx].connect(addr)

--- a/trollcast/client.py
+++ b/trollcast/client.py
@@ -659,6 +659,7 @@ class Client(HaveBuffer):
 
                 except Empty:
                     pass
+                to_be_deleted = []
                 for sat, (utctime, elevation) in sat_last_seen.items():
                     if (utctime + CLIENT_TIMEOUT < datetime.utcnow() or
                         (utctime + timedelta(seconds=3) < datetime.utcnow() and
@@ -723,9 +724,12 @@ class Client(HaveBuffer):
                             continue
                         finally:
                             sat_lines[sat] = {}
-                            del sat_last_seen[sat]
+                            to_be_deleted.append(sat)
                             first_time = None
+                for sat in to_be_deleted:
+                    del sat_last_seen[sat]
         except KeyboardInterrupt:
+            to_be_deleted = []
             for sat, (utctime, elevation) in sat_last_seen.items():
                 logger.info(sat + ": writing file.")
                 first_time = (first_time
@@ -736,6 +740,7 @@ class Client(HaveBuffer):
                         fp_.write(sat_lines[sat][linetime])
 
                 sat_lines[sat] = {}
+            for sat in to_be_deleted:
                 del sat_last_seen[sat]
             raise
 

--- a/trollcast/client.py
+++ b/trollcast/client.py
@@ -638,6 +638,8 @@ class Client(HaveBuffer):
                                                                       x[1])))
                     best_req = None
                     for sender, elevation, quality, ping_time in reversed(sender_elevation_quality):
+                        if not elevation or not quality:
+                            continue
                         best_req = self._requesters[sender.split(":")[0]]
                         if best_req.jammed:
                             continue

--- a/trollcast/client.py
+++ b/trollcast/client.py
@@ -41,8 +41,7 @@ from urllib.parse import urlsplit, urlunparse
 
 import numpy as np
 from zmq import (LINGER, POLLIN, REQ, SUB, SUBSCRIBE, Context, Poller,
-                 zmq_version)
-
+                 zmq_version, ZMQError)
 
 from posttroll import get_context
 from posttroll.message import Message, strp_isoformat
@@ -268,9 +267,12 @@ class SimpleRequester(object):
     def stop(self):
         """Close the connection to the server
         """
-        self._socket.setsockopt(LINGER, 0)
-        self._socket.close()
-        self._poller.unregister(self._socket)
+        try:
+            self._socket.setsockopt(LINGER, 0)
+            self._socket.close()
+            self._poller.unregister(self._socket)
+        except ZMQError:
+            pass
 
     def reset_connection(self):
         """Reset the socket

--- a/trollcast/client.py
+++ b/trollcast/client.py
@@ -652,6 +652,9 @@ class Client(HaveBuffer):
                             logger.warning("Could not retrieve line %s",
                                            str(utctime))
                         else:
+                            # Convert the data to bytes
+                            if isinstance(line, str):
+                                line = bytes(line, 'UTF-8')
                             sat_lines[sat][utctime] = line
                             if first_time is None and quality == 100:
                                 first_time = utctime

--- a/trollcast/server.py
+++ b/trollcast/server.py
@@ -28,7 +28,7 @@ TODO:
 """
 
 from trollcast.client import SimpleRequester, REQ_TIMEOUT
-from configparser import ConfigParser, NoOptionError
+from configparser import RawConfigParser, NoOptionError
 from zmq import Context, Poller, LINGER, PUB, REP, POLLIN, NOBLOCK, SUB, SUBSCRIBE, ZMQError
 from threading import Thread, Event, Lock, Timer
 from posttroll.message import Message
@@ -557,7 +557,7 @@ class MirrorWatcher(Thread):
 
         self._subsocket = get_context().socket(SUB)
         self._subsocket.connect(self._pubaddress)
-        self._subsocket.setsockopt(SUBSCRIBE, "pytroll")
+        self._subsocket.setsockopt_string(SUBSCRIBE, "pytroll")
         self._poller = Poller()
         self._poller.register(self._subsocket, POLLIN)
         self._lock = Lock()
@@ -738,7 +738,7 @@ class Publisher(object):
         """Publish something
         """
         with self._lock:
-            self._socket.send(str(message))
+            self._socket.send_string(str(message))
 
     def stop(self):
         """Stop publishing.
@@ -845,7 +845,7 @@ class RequestManager(Thread):
             logger.debug("Response: " + " ".join(str(message).split()[:6]))
         else:
             logger.debug("Response: " + str(message))
-        self._socket.send(str(message))
+        self._socket.send_string(str(message))
 
     def pong(self):
         """Reply to ping
@@ -928,7 +928,7 @@ def serve(configfile):
     """
 
     try:
-        cfg = ConfigParser()
+        cfg = RawConfigParser()
         cfg.read(configfile)
 
         host = cfg.get("local_reception", "localhost")

--- a/trollcast/tests/test_server.py
+++ b/trollcast/tests/test_server.py
@@ -87,8 +87,8 @@ class TestPublisher(unittest.TestCase):
         context.socket.return_value.send.side_effect = None
         pub.send("send 2")
         thr.join()
-        self.assertEquals(pub._socket.send.call_args_list[0][0][0], "send 1")
-        self.assertEquals(pub._socket.send.call_args_list[1][0][0], "send 2")
+        self.assertEquals(pub._socket.send_string.call_args_list[0][0][0], "send 1")
+        self.assertEquals(pub._socket.send_string.call_args_list[1][0][0], "send 2")
 
 class TestHolder(unittest.TestCase):
 
@@ -263,7 +263,7 @@ class TestServe(unittest.TestCase):
                           MirrorWatcher, RequestManager, ScheduleReader, sleep):
         """Test serving from a mirror
         """
-        server.ConfigParser.return_value.read.reset_mock()
+        server.RawConfigParser.return_value.read.reset_mock()
         server.Context.return_value.term.reset_mock()
         server.time.sleep = MagicMock(side_effect=KeyboardInterrupt())
         mirrorcfg = ["this_computer", "neverwhere", "360 180 100",
@@ -272,14 +272,14 @@ class TestServe(unittest.TestCase):
                      server.NoOptionError("boom"),
                      "amore_mio",
                      "/under/the/rainbow/", "wtf?", "bluebird", "mirror", "the_other_place"]
-        server.ConfigParser.return_value.get = MagicMock(side_effect=mirrorcfg)
+        server.RawConfigParser.return_value.get = MagicMock(side_effect=mirrorcfg)
         mirrorcfg = [666, 667, 668, 669]
-        server.ConfigParser.return_value.getint = MagicMock(side_effect=mirrorcfg)
+        server.RawConfigParser.return_value.getint = MagicMock(side_effect=mirrorcfg)
         server.serve("test_config.cfg")
 
         # Config reading
 
-        server.ConfigParser.return_value.read.assert_called_once_with("test_config.cfg")
+        server.RawConfigParser.return_value.read.assert_called_once_with("test_config.cfg")
 
         # publisher
         Publisher.assert_called_once_with(666)
@@ -329,7 +329,7 @@ class TestServe(unittest.TestCase):
                           MirrorWatcher, RequestManager, ScheduleReader, sleep):
         """Test serving from a file
         """
-        server.ConfigParser.return_value.read.reset_mock()
+        server.RawConfigParser.return_value.read.reset_mock()
         server.Context.return_value.term.reset_mock()
         server.time.sleep = MagicMock(side_effect=KeyboardInterrupt())
         server.NoOptionError = Exception
@@ -338,13 +338,13 @@ class TestServe(unittest.TestCase):
                    "schedformat", "amore_mio",
                    "/tmp", "*.hmf",
                    server.NoOptionError("boom")]
-        server.ConfigParser.return_value.get = MagicMock(side_effect=filecfg)
+        server.RawConfigParser.return_value.get = MagicMock(side_effect=filecfg)
         filecfg = [666, 667, 668, 669]
-        server.ConfigParser.return_value.getint = MagicMock(side_effect=filecfg)
+        server.RawConfigParser.return_value.getint = MagicMock(side_effect=filecfg)
         server.serve("test_config.cfg")
 
         # Config reading
-        server.ConfigParser.return_value.read.assert_called_once_with("test_config.cfg")
+        server.RawConfigParser.return_value.read.assert_called_once_with("test_config.cfg")
 
         # publisher
         Publisher.assert_called_once_with(666)

--- a/trollcast/tests/test_server.py
+++ b/trollcast/tests/test_server.py
@@ -87,8 +87,11 @@ class TestPublisher(unittest.TestCase):
         context.socket.return_value.send.side_effect = None
         pub.send("send 2")
         thr.join()
-        self.assertEquals(pub._socket.send_string.call_args_list[0][0][0], "send 1")
-        self.assertEquals(pub._socket.send_string.call_args_list[1][0][0], "send 2")
+        self.assertEquals(
+            pub._socket.send_string.call_args_list[0][0][0], "send 1")
+        self.assertEquals(
+            pub._socket.send_string.call_args_list[1][0][0], "send 2")
+
 
 class TestHolder(unittest.TestCase):
 
@@ -272,14 +275,17 @@ class TestServe(unittest.TestCase):
                      server.NoOptionError("boom"),
                      "amore_mio",
                      "/under/the/rainbow/", "wtf?", "bluebird", "mirror", "the_other_place"]
-        server.RawConfigParser.return_value.get = MagicMock(side_effect=mirrorcfg)
+        server.RawConfigParser.return_value.get = MagicMock(
+            side_effect=mirrorcfg)
         mirrorcfg = [666, 667, 668, 669]
-        server.RawConfigParser.return_value.getint = MagicMock(side_effect=mirrorcfg)
+        server.RawConfigParser.return_value.getint = MagicMock(
+            side_effect=mirrorcfg)
         server.serve("test_config.cfg")
 
         # Config reading
 
-        server.RawConfigParser.return_value.read.assert_called_once_with("test_config.cfg")
+        server.RawConfigParser.return_value.read.assert_called_once_with(
+            "test_config.cfg")
 
         # publisher
         Publisher.assert_called_once_with(666)
@@ -338,13 +344,16 @@ class TestServe(unittest.TestCase):
                    "schedformat", "amore_mio",
                    "/tmp", "*.hmf",
                    server.NoOptionError("boom")]
-        server.RawConfigParser.return_value.get = MagicMock(side_effect=filecfg)
+        server.RawConfigParser.return_value.get = MagicMock(
+            side_effect=filecfg)
         filecfg = [666, 667, 668, 669]
-        server.RawConfigParser.return_value.getint = MagicMock(side_effect=filecfg)
+        server.RawConfigParser.return_value.getint = MagicMock(
+            side_effect=filecfg)
         server.serve("test_config.cfg")
 
         # Config reading
-        server.RawConfigParser.return_value.read.assert_called_once_with("test_config.cfg")
+        server.RawConfigParser.return_value.read.assert_called_once_with(
+            "test_config.cfg")
 
         # publisher
         Publisher.assert_called_once_with(666)


### PR DESCRIPTION
The behaviour of socket options and sending has changed since Python 2.7. This fixes the errors for Python 3, which complaint that `unicode` isn't allowed.

Also the behaviour of `ConfigParser` has changed, so we'll now use `RawConfigParser` so that the filename patterns do not cause a crash.

So far I have only been able to communicate with our local reception, and no overpasses have occured since. I'll report how it goes after the first overpass has happened. The reception server is still running the old version with Python 2.7.